### PR TITLE
Changing home page to display all Teams, modified styling and display

### DIFF
--- a/components/TeamCard/TeamCard.module.css
+++ b/components/TeamCard/TeamCard.module.css
@@ -1,0 +1,29 @@
+.root {
+  display: flex;
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.content {
+  flex: 1 0 auto;
+  align-items: center;
+}
+
+.cover {
+  width: 151px;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  padding-top: 0.5em;
+}
+
+.playIcon {
+  height: 38px;
+  width: 38px;
+}

--- a/components/TeamCard/TeamCard.tsx
+++ b/components/TeamCard/TeamCard.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {
+  Button,
+  Grid,
+  Card,
+  CardActionArea,
+  CardActions,
+  CardContent,
+  CardMedia,
+  Typography,
+  IconButton,
+} from '@material-ui/core';
+import styles from './TeamCard.module.css';
+import { TeamSimple } from '../../src/graphql/types';
+
+export interface TeamCardProps {
+  team: TeamSimple;
+}
+
+const TeamCard = ({ team }: TeamCardProps) => {
+  return (
+    <Card className={styles.root}>
+      <CardMedia
+        className={styles.cover}
+        image={team.team_logos[0]?.url}
+        title='Team Logo'
+      />
+      <div className={styles.details}>
+        <CardContent className={styles.content}>
+          <Typography component='h5' variant='h5'>
+            {team.name}
+          </Typography>
+          <Typography variant='subtitle1' color='textSecondary'>
+            {team.managers.map((manager: any, m: number) =>
+              manager?.is_comanager == null ? (
+                <div key={m}>Manager: {manager?.nickname} </div>
+              ) : (
+                <div key={m}>Co-manager: {manager?.nickname}</div>
+              )
+            )}
+          </Typography>
+          <div className={styles.controls}>
+            <Button size='medium' variant='outlined' color='primary'>
+              <Typography>VIEW TEAM</Typography>
+            </Button>
+          </div>
+        </CardContent>
+      </div>
+    </Card>
+  );
+};
+
+export default TeamCard;

--- a/components/Teams/Teams.tsx
+++ b/components/Teams/Teams.tsx
@@ -1,6 +1,8 @@
 import { gql } from '@apollo/client';
 import { useTeamQuery } from '../../src/graphql/types';
 import { useIndexQuery } from '../../src/graphql/types';
+import TeamCard from '../TeamCard/TeamCard';
+import { Grid } from '@material-ui/core';
 
 interface Props {
   team_id: string;
@@ -31,28 +33,19 @@ gql`
 `;
 const Teams = () => {
   const { data, loading } = useIndexQuery();
-  const teamList = data?.allTeams.map((team, i) =>
-    team.team_logos.map((logo, l) => (
-      <li key={i}>
-        <div>Team Name: {team.name}</div>
-        <img src={logo?.url} alt='team logo' />
-        {team.managers.map((manager, m) =>
-          manager?.is_comanager == null ? (
-            <div key={m}>Manager: {manager?.nickname} </div>
-          ) : (
-            <div key={m}>Co-manager: {manager?.nickname}</div>
-          )
-        )}
-      </li>
-    ))
-  );
+  const teamList = data?.allTeams.map((team, i) => (
+    <>
+      <Grid item>
+        <TeamCard team={team} />
+      </Grid>
+    </>
+  ));
   let content = <div>Loading ...</div>;
   if (!loading && data) {
     content = (
-      <>
-        <h2>KOTKL TEAMS:</h2>
-        <ul>{teamList}</ul>
-      </>
+      <Grid container xs={5} direction='column' spacing={6}>
+        {teamList}
+      </Grid>
     );
   }
   return content;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,69 +1,20 @@
 import Head from 'next/head';
 import styles from '../styles/Home.module.css';
-import PlayerCard from '../components/PlayerCard/PlayerCard';
-import Team from '../components/Team/Team';
-import className from 'classnames';
-import {Button} from '../components/Button/Button';
+import Teams from '../components/Teams/Teams';
 
 export default function Home() {
   return (
     <div className={styles.container}>
       <Head>
-        <title>Create Next App</title>
+        <title>KOTKL</title>
         <link rel='icon' href='/favicon.ico' />
       </Head>
       <main className={styles.main}>
-      {/*this is a comment */}
-      <Button title='Another Button Title'>
-      </Button>
         <h1 className={styles.title}>
-          Welcome to <a href='https://nextjs.org'>Next.js!</a>
+          Welcome to Knights of the Keeper League!
         </h1>
-        <Team />
-
-        <h1 className={className(styles.description, 'p-5')}>
-          Here is a sample Player Card
-        </h1>
-        <PlayerCard name='Kobe Bryant' team='Los Angeles Lakers' cost='$225' />
-
-        <hr className='p-5' />
-
-        <p className={styles.description}>
-          Get started by editing{' '}
-          <code className={styles.code}>pages/index.js</code>
-        </p>
-
-        <div className={styles.grid}>
-          <a href='https://nextjs.org/docs' className={styles.card}>
-            <h3>Documentation &rarr;</h3>
-            <p>Find in-depth information about Next.js features and API.</p>
-          </a>
-
-          <a href='https://nextjs.org/learn' className={styles.card}>
-            <h3>Learn &rarr;</h3>
-            <p>Learn about Next.js in an interactive course with quizzes!</p>
-          </a>
-
-          <a
-            href='https://github.com/vercel/next.js/tree/master/examples'
-            className={styles.card}
-          >
-            <h3>Examples &rarr;</h3>
-            <p>Discover and deploy boilerplate example Next.js projects.</p>
-          </a>
-
-          <a
-            href='https://vercel.com/import?filter=next.js&utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app'
-            className={styles.card}
-          >
-            <h3>Deploy &rarr;</h3>
-            <p>
-              Instantly deploy your Next.js site to a public URL with Vercel.
-            </p>
-          </a>
-        </div>
+        <Teams />
       </main>
-
       <footer className={styles.footer}>
         <a
           href='https://vercel.com?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app'

--- a/src/dao/types.ts
+++ b/src/dao/types.ts
@@ -27,12 +27,19 @@ export type QueryTeamArgs = {
 export type Manager = {
   manager_id: Scalars['String'];
   nickname: Scalars['String'];
-  email: Scalars['String'];
+  email?: Maybe<Scalars['String']>;
   is_comanager?: Maybe<Scalars['String']>;
 };
 
 export type TeamLogos = {
   url: Scalars['String'];
+};
+
+export type TeamSimple = {
+  team_id: Scalars['String'];
+  name: Scalars['String'];
+  managers: Array<Maybe<Manager>>;
+  team_logos: Array<Maybe<TeamLogos>>;
 };
 
 export type TeamMvc = {
@@ -57,12 +64,19 @@ import { ObjectID } from 'mongodb';
 export type ManagerDbObject = {
   manager_id: string;
   nickname: string;
-  email: string;
+  email?: Maybe<string>;
   is_comanager?: Maybe<string>;
 };
 
 export type TeamLogosDbObject = {
   url: string;
+};
+
+export type TeamSimpleDbObject = {
+  team_id: string;
+  name: string;
+  managers: Array<Maybe<Manager>>;
+  team_logos: Array<Maybe<TeamLogos>>;
 };
 
 export type TeamMvcDbObject = {

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -6,12 +6,19 @@ type Query {
 type Manager @entity {
   manager_id: String! @column
   nickname: String! @column
-  email: String! @column
+  email: String @column
   is_comanager: String @column
 }
 
 type TeamLogos @entity {
   url: String! @column
+}
+
+type TeamSimple @entity {
+  team_id: String! @column
+  name: String! @column
+  managers: [Manager]! @column
+  team_logos: [TeamLogos]! @column
 }
 
 type TeamMVC @entity {

--- a/src/graphql/types.tsx
+++ b/src/graphql/types.tsx
@@ -35,12 +35,19 @@ export type QueryTeamArgs = {
 export type Manager = {
   manager_id: Scalars['String'];
   nickname: Scalars['String'];
-  email: Scalars['String'];
+  email?: Maybe<Scalars['String']>;
   is_comanager?: Maybe<Scalars['String']>;
 };
 
 export type TeamLogos = {
   url: Scalars['String'];
+};
+
+export type TeamSimple = {
+  team_id: Scalars['String'];
+  name: Scalars['String'];
+  managers: Array<Maybe<Manager>>;
+  team_logos: Array<Maybe<TeamLogos>>;
 };
 
 export type TeamMvc = {
@@ -176,6 +183,7 @@ export type ResolversTypes = {
   String: ResolverTypeWrapper<Scalars['String']>;
   Manager: ResolverTypeWrapper<Manager>;
   TeamLogos: ResolverTypeWrapper<TeamLogos>;
+  TeamSimple: ResolverTypeWrapper<TeamSimple>;
   TeamMVC: ResolverTypeWrapper<TeamMvc>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -187,6 +195,7 @@ export type ResolversParentTypes = {
   String: Scalars['String'];
   Manager: Manager;
   TeamLogos: TeamLogos;
+  TeamSimple: TeamSimple;
   TeamMVC: TeamMvc;
   Int: Scalars['Int'];
   Boolean: Scalars['Boolean'];
@@ -215,7 +224,7 @@ export type ManagerResolvers<
 > = {
   manager_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   nickname?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   is_comanager?: Resolver<
     Maybe<ResolversTypes['String']>,
     ParentType,
@@ -229,6 +238,25 @@ export type TeamLogosResolvers<
   ParentType extends ResolversParentTypes['TeamLogos'] = ResolversParentTypes['TeamLogos']
 > = {
   url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type TeamSimpleResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TeamSimple'] = ResolversParentTypes['TeamSimple']
+> = {
+  team_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  managers?: Resolver<
+    Array<Maybe<ResolversTypes['Manager']>>,
+    ParentType,
+    ContextType
+  >;
+  team_logos?: Resolver<
+    Array<Maybe<ResolversTypes['TeamLogos']>>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -269,6 +297,7 @@ export type Resolvers<ContextType = any> = {
   Query?: QueryResolvers<ContextType>;
   Manager?: ManagerResolvers<ContextType>;
   TeamLogos?: TeamLogosResolvers<ContextType>;
+  TeamSimple?: TeamSimpleResolvers<ContextType>;
   TeamMVC?: TeamMvcResolvers<ContextType>;
 };
 

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -50,6 +50,7 @@
   margin: 0;
   line-height: 1.15;
   font-size: 4rem;
+  padding-bottom: 1em;
 }
 
 .title,


### PR DESCRIPTION
Fixes #23 

Cleaned up our home page, it should now just display all our teams. 

Had to create a new type for the simplified teams data we were getting back.

@bensonlau take a look at the changes, once you get your styles in, I want to change how we're doing styling to leverage the material-ui/styles. I'm just using regular css files for now. I'll create a separate issue for fixing that and assign it to you. Specifically this file: components/TeamCard/TeamCard.module.css 